### PR TITLE
Quick fix

### DIFF
--- a/events/inviteDetect.js
+++ b/events/inviteDetect.js
@@ -19,6 +19,10 @@ var containsDiscordUrl = regex.test(message.content);
       if(containsDiscordUrl) {
   var link = regex.exec(message.content);
         
+
+
+if(message.member.roles.highest.position > message.guild.roles.cache.get("931765896039497788").position) return;
+
 if(link && !message.author.bot) {
 discordInv.getInv(discordInv.getCodeFromUrl('https://' + link[0])).then((invite) => {
 

--- a/events/inviteDetect.js
+++ b/events/inviteDetect.js
@@ -21,7 +21,7 @@ var containsDiscordUrl = regex.test(message.content);
         
 
 
-if(message.member.roles.highest.position > message.guild.roles.cache.get("931765896039497788").position) return;
+if(message.member.roles.highest.position > message.guild.roles.cache.get("949476126777049109").position) return;
 
 if(link && !message.author.bot) {
 discordInv.getInv(discordInv.getCodeFromUrl('https://' + link[0])).then((invite) => {


### PR DESCRIPTION
Invite Link sent by admins or staff doesn't get deleted now. I saw Zoar kicked the bot cuz when he sent a link in the giveaway channel, the bot deleted it. It should not delete them anymore.